### PR TITLE
don't panic when fetch returns a single error

### DIFF
--- a/template.go
+++ b/template.go
@@ -80,7 +80,7 @@ func (l *{{.LoaderName}}) LoadThunk(key {{.KeyType}}) func() ({{.ValType}}, erro
 		var err error
 		// its convenient to be able to return a single error for everything
 		if len(batch.error) == 1 {
-			err = batch.error[pos]
+			err = batch.error[0]
 		} else if batch.error != nil {
 			err = batch.error[pos]
 		}


### PR DESCRIPTION
occasionally we were hitting a point in our codepath where we were returning a single error from our fetch func back to dataloaden. Doing so ended up causing a panic `index out of range`.

the conditions seem to be if multiple keys get passed into `fetch()` but we only return a slice of 1 error. `LoadThunk` would get the key index and later use that index to set the error, however if 40 items were passed into `fetch()`, we get an our of range panic

simplified example:
```golang
func newMemberLoader(ctx context.Context, db *sqlx.DB) *MemberResolverLoader {
	return &MemberResolverLoader{
		maxBatch: 100,
		wait:     10 * time.Millisecond,
		fetch: func(keys []string) ([]*MemberResolver, []error) {
			return nil, []error{errors.New("an error!")}
		},
	}
}
```
