### PR TITLE
Copy values when priming the cache

### DIFF
--- a/dataloaden.go
+++ b/dataloaden.go
@@ -29,6 +29,7 @@ type templateData struct {
 	KeyType    string
 	ValType    string
 	Import     string
+	Slice      bool
 }
 
 func main() {
@@ -46,7 +47,7 @@ func main() {
 	}
 
 	filename := data.Name + "loader_gen.go"
-	if *slice {
+	if data.Slice {
 		filename = data.Name + "sliceloader_gen.go"
 	}
 
@@ -72,6 +73,7 @@ func getData(typeName string) (templateData, error) {
 	data.BatchName = lcFirst(name) + "Batch"
 	data.Name = lcFirst(name)
 	data.KeyType = *keyType
+	data.Slice = *slice
 
 	prefix := "*"
 	if *slice {

--- a/example/pkgname/userloader_gen.go
+++ b/example/pkgname/userloader_gen.go
@@ -114,7 +114,10 @@ func (l *UserLoader) Prime(key string, value *example.User) bool {
 	l.mu.Lock()
 	var found bool
 	if _, found = l.cache[key]; !found {
-		l.unsafeSet(key, value)
+		// make a copy when writing to the cache, its easy to pass a pointer in from a loop var
+		// and end up with the whole cache pointing to the same value.
+		cpy := *value
+		l.unsafeSet(key, &cpy)
 	}
 	l.mu.Unlock()
 	return !found

--- a/example/user_test.go
+++ b/example/user_test.go
@@ -146,6 +146,26 @@ func TestUserLoader(t *testing.T) {
 		require.Len(t, fetches, 3)
 	})
 
+	t.Run("priming in a loop is safe", func(t *testing.T) {
+		users := []User{
+			{ID: "Alpha", Name: "Alpha"},
+			{ID: "Omega", Name: "Omega"},
+		}
+		for _, user := range users {
+			dl.Prime(user.ID, &user)
+		}
+
+		u, err := dl.Load("Alpha")
+		require.NoError(t, err)
+		require.Equal(t, "Alpha", u.Name)
+
+		u, err = dl.Load("Omega")
+		require.NoError(t, err)
+		require.Equal(t, "Omega", u.Name)
+
+		require.Len(t, fetches, 3)
+	})
+
 	t.Run("cleared results will go back to the fetcher", func(t *testing.T) {
 		dl.Clear("U99")
 		u, err := dl.Load("U99")

--- a/example/userloader_gen.go
+++ b/example/userloader_gen.go
@@ -112,7 +112,10 @@ func (l *UserLoader) Prime(key string, value *User) bool {
 	l.mu.Lock()
 	var found bool
 	if _, found = l.cache[key]; !found {
-		l.unsafeSet(key, value)
+		// make a copy when writing to the cache, its easy to pass a pointer in from a loop var
+		// and end up with the whole cache pointing to the same value.
+		cpy := *value
+		l.unsafeSet(key, &cpy)
 	}
 	l.mu.Unlock()
 	return !found

--- a/template.go
+++ b/template.go
@@ -119,7 +119,14 @@ func (l *{{.LoaderName}}) Prime(key {{.KeyType}}, value {{.ValType}}) bool {
 	l.mu.Lock()
 	var found bool
 	if _, found = l.cache[key]; !found {
-		l.unsafeSet(key, value)
+		{{- if .Slice }}
+			l.unsafeSet(key, value)
+		{{- else }}
+			// make a copy when writing to the cache, its easy to pass a pointer in from a loop var
+			// and end up with the whole cache pointing to the same value.
+			cpy := *value
+			l.unsafeSet(key, &cpy)
+		{{- end }}
 	}
 	l.mu.Unlock()
 	return !found


### PR DESCRIPTION
This prevents the cache all pointing to the same value when priming from a list of slices and passing a reference in.