### PR TITLE
Fixes issue where dataloader package would be a test package

### DIFF
--- a/dataloaden.go
+++ b/dataloaden.go
@@ -102,6 +102,9 @@ func getPackage(wd string) string {
 	}
 	if len(results) > 0 {
 		for pkgName := range results {
+			if strings.HasSuffix(pkgName, "_test") {
+				continue
+			}
 			return pkgName
 		}
 	}


### PR DESCRIPTION
Noticed this issue popping up when I was generating my loaders. 

I think it highly depends on the order of the range for the map after parser.ParseDir is called