### PR TITLE
Pointer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Slice of pointers to value:
 dataloaden []*github.com/dataloaden/example.User
 ```
 
-Now each key is expected to return a slice of pointer to value and the `fetch` function has the return type `[][]*User`.
+Now each key is expected to return a slice of pointers to value and the `fetch` function has the return type `[][]*User`.
 
 #### Using with go modules
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go get -u github.com/vektah/dataloaden
 
 then from inside the package you want to have the dataloader in:
 ```bash
-dataloaden github.com/dataloaden/example.User
+dataloaden *github.com/dataloaden/example.User
 ```
 
 In another file in the same package, create the constructor method:
@@ -51,27 +51,23 @@ function once. It also caches values and wont request duplicates in a batch.
 
 #### Returning Slices
 
-You may want to generate a dataloader that returns slices instead of single values. This can be done using the `-slice` flag:
-
 ```bash
-dataloaden -slice github.com/dataloaden/example.User
+dataloaden []github.com/dataloaden/example.User
 ```
 
 Now each key is expected to return a slice of values and the `fetch` function has the return type `[][]User`.
 
 #### Returning pointers
 
-This can be done using the `-pointer` flag:
-
 ```bash
-dataloaden -pointer github.com/dataloaden/example.User
+dataloaden *github.com/dataloaden/example.User
 ```
 
 Now each key is expected to return a pointer to value and the `fetch` function has the return type `[]*User`.
 
-Slice of pointer to value:
+Slice of pointers to value:
 ```bash
-dataloaden -slice -pointer github.com/dataloaden/example.User
+dataloaden []*github.com/dataloaden/example.User
 ```
 
 Now each key is expected to return a slice of pointer to value and the `fetch` function has the return type `[][]*User`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ dataloaden -slice github.com/dataloaden/example.User
 
 Now each key is expected to return a slice of values and the `fetch` function has the return type `[][]User`.
 
+#### Returning pointers
+
+This can be done using the `-pointer` flag:
+
+```bash
+dataloaden -pointer github.com/dataloaden/example.User
+```
+
+Now each key is expected to return a pointer to value and the `fetch` function has the return type `[]*User`.
+
+Slice of pointer to value:
+```bash
+dataloaden -slice -pointer github.com/dataloaden/example.User
+```
+
+Now each key is expected to return a slice of pointer to value and the `fetch` function has the return type `[][]*User`.
+
 #### Using with go modules
 
 Create a tools.go that looks like this:

--- a/dataloaden.go
+++ b/dataloaden.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	keyType := flag.String("keys", "int", "what type should the keys be")
 	slice := flag.Bool("slice", false, "this dataloader will return slices")
+	pointer := flag.Bool("pointer", false, "this dataloader will return pointer")
 
 	flag.Parse()
 
@@ -26,7 +27,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	if err := generator.Generate(flag.Arg(0), *keyType, *slice, wd); err != nil {
+	if err := generator.Generate(flag.Arg(0), *keyType, *slice, *pointer, wd); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(2)
 	}

--- a/dataloaden.go
+++ b/dataloaden.go
@@ -10,8 +10,6 @@ import (
 
 func main() {
 	keyType := flag.String("keys", "int", "what type should the keys be")
-	slice := flag.Bool("slice", false, "this dataloader will return slices")
-	pointer := flag.Bool("pointer", false, "this dataloader will return pointer")
 
 	flag.Parse()
 
@@ -27,7 +25,14 @@ func main() {
 		os.Exit(2)
 	}
 
-	if err := generator.Generate(flag.Arg(0), *keyType, *slice, *pointer, wd); err != nil {
+	valueType, err := generator.NewValueTypeFromString(flag.Arg(0))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+
+	if err := generator.Generate(valueType, *keyType, wd); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(2)
 	}

--- a/example/pkgname/user.go
+++ b/example/pkgname/user.go
@@ -1,3 +1,3 @@
 package differentpkg
 
-//go:generate go run github.com/vektah/dataloaden -keys string github.com/vektah/dataloaden/example.User
+//go:generate go run github.com/vektah/dataloaden -keys string -pointer github.com/vektah/dataloaden/example.User

--- a/example/pkgname/user.go
+++ b/example/pkgname/user.go
@@ -1,3 +1,3 @@
 package differentpkg
 
-//go:generate go run github.com/vektah/dataloaden -keys string -pointer github.com/vektah/dataloaden/example.User
+//go:generate go run github.com/vektah/dataloaden -keys string *github.com/vektah/dataloaden/example.User

--- a/example/slice/user.go
+++ b/example/slice/user.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/vektah/dataloaden -keys int -slice github.com/vektah/dataloaden/example.User
+//go:generate go run github.com/vektah/dataloaden -keys int []github.com/vektah/dataloaden/example.User
 
 package slice
 

--- a/example/user.go
+++ b/example/user.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/vektah/dataloaden -keys string github.com/vektah/dataloaden/example.User
+//go:generate go run github.com/vektah/dataloaden -keys string -pointer github.com/vektah/dataloaden/example.User
 
 package example
 

--- a/example/user.go
+++ b/example/user.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/vektah/dataloaden -keys string -pointer github.com/vektah/dataloaden/example.User
+//go:generate go run github.com/vektah/dataloaden -keys string *github.com/vektah/dataloaden/example.User
 
 package example
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -24,8 +24,8 @@ type templateData struct {
 	Slice      bool
 }
 
-func Generate(typename string, keyType string, slice bool, wd string) error {
-	data, err := getData(typename, keyType, slice, wd)
+func Generate(typename string, keyType string, slice bool, pointer bool, wd string) error {
+	data, err := getData(typename, keyType, slice, pointer, wd)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func Generate(typename string, keyType string, slice bool, wd string) error {
 	return nil
 }
 
-func getData(typeName string, keyType string, slice bool, wd string) (templateData, error) {
+func getData(typeName string, keyType string, slice bool, pointer bool, wd string) (templateData, error) {
 	var data templateData
 	parts := strings.Split(typeName, ".")
 	if len(parts) < 2 {
@@ -64,11 +64,15 @@ func getData(typeName string, keyType string, slice bool, wd string) (templateDa
 	data.KeyType = keyType
 	data.Slice = slice
 
-	prefix := "*"
+	prefix := ""
 	if slice {
 		prefix = "[]"
 		data.LoaderName = name + "SliceLoader"
 		data.BatchName = lcFirst(name) + "SliceBatch"
+	}
+
+	if pointer {
+		prefix = prefix + "*"
 	}
 
 	// if we are inside the same package as the type we don't need an import and can refer directly to the type

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeParsing(t *testing.T) {
+	valueType, err := NewValueTypeFromString("github.com/dataloaden/example.User")
+
+	require.NoError(t, err)
+
+	assert.Equal(t, &ValueType{
+		Name:       "User",
+		ImportPath: "github.com/dataloaden/example",
+	}, valueType)
+}
+
+func TestTypeParsingWithSlice(t *testing.T) {
+	valueType, err := NewValueTypeFromString("[]github.com/dataloaden/example.User")
+
+	require.NoError(t, err)
+
+	assert.Equal(t, &ValueType{
+		Name:       "User",
+		ImportPath: "github.com/dataloaden/example",
+		IsSlice:    true,
+	}, valueType)
+}
+
+func TestTypeParsingWithPointer(t *testing.T) {
+	valueType, err := NewValueTypeFromString("*github.com/dataloaden/example.User")
+
+	require.NoError(t, err)
+
+	assert.Equal(t, &ValueType{
+		Name:       "User",
+		ImportPath: "github.com/dataloaden/example",
+		IsPointer:  true,
+	}, valueType)
+}
+
+func TestTypeParsingWithSliceOfPointers(t *testing.T) {
+	valueType, err := NewValueTypeFromString("[]*github.com/dataloaden/example.User")
+
+	require.NoError(t, err)
+
+	assert.Equal(t, &ValueType{
+		Name:       "User",
+		ImportPath: "github.com/dataloaden/example",
+		IsSlice:    true,
+		IsPointer:  true,
+	}, valueType)
+}
+
+func TestTypeParsingInvalidType(t *testing.T) {
+	valueType, err := NewValueTypeFromString("somethingWrong")
+
+	require.Error(t, err)
+	assert.Nil(t, valueType)
+}


### PR DESCRIPTION
For now there is no way to return slice of pointers to value (common case in grpc for repeated fields). 
Proposed add  new `-pointer` flag that can works with/without `-slice` option.
This is backward incompatible change.