### PR TITLE
Recover from panics that happen during fetch

### DIFF
--- a/example/pkgname/userloader_gen.go
+++ b/example/pkgname/userloader_gen.go
@@ -3,6 +3,7 @@
 package differentpkg
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -19,6 +20,10 @@ type UserLoaderConfig struct {
 
 	// MaxBatch will limit the maximum number of keys to send in one batch, 0 = not limit
 	MaxBatch int
+
+	// Recover is a function to transform a recovered value into an error.
+	// If a function is not supplied, the value is formatted with fmt.Errorf("%v", v).
+	Recover func(v interface{}) error
 }
 
 // NewUserLoader creates a new UserLoader given a fetch, wait, and maxBatch
@@ -27,6 +32,7 @@ func NewUserLoader(config UserLoaderConfig) *UserLoader {
 		fetch:    config.Fetch,
 		wait:     config.Wait,
 		maxBatch: config.MaxBatch,
+		recover:  config.Recover,
 	}
 }
 
@@ -40,6 +46,9 @@ type UserLoader struct {
 
 	// this will limit the maximum number of keys to send in one batch, 0 = no limit
 	maxBatch int
+
+	// this transforms recovered panic values into errors
+	recover func(v interface{}) error
 
 	// INTERNAL
 
@@ -219,6 +228,15 @@ func (b *userLoaderBatch) startTimer(l *UserLoader) {
 }
 
 func (b *userLoaderBatch) end(l *UserLoader) {
+	defer func() {
+		if r := recover(); r != nil {
+			if l.recover != nil {
+				b.error = []error{l.recover(r)}
+			} else {
+				b.error = []error{fmt.Errorf("%v", r)}
+			}
+		}
+	}()
 	b.data, b.error = l.fetch(b.keys)
 	close(b.done)
 }

--- a/example/slice/usersliceloader_gen.go
+++ b/example/slice/usersliceloader_gen.go
@@ -3,6 +3,7 @@
 package slice
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -19,6 +20,10 @@ type UserSliceLoaderConfig struct {
 
 	// MaxBatch will limit the maximum number of keys to send in one batch, 0 = not limit
 	MaxBatch int
+
+	// Recover is a function to transform a recovered value into an error.
+	// If a function is not supplied, the value is formatted with fmt.Errorf("%v", v).
+	Recover func(v interface{}) error
 }
 
 // NewUserSliceLoader creates a new UserSliceLoader given a fetch, wait, and maxBatch
@@ -27,6 +32,7 @@ func NewUserSliceLoader(config UserSliceLoaderConfig) *UserSliceLoader {
 		fetch:    config.Fetch,
 		wait:     config.Wait,
 		maxBatch: config.MaxBatch,
+		recover:  config.Recover,
 	}
 }
 
@@ -40,6 +46,9 @@ type UserSliceLoader struct {
 
 	// this will limit the maximum number of keys to send in one batch, 0 = no limit
 	maxBatch int
+
+	// this transforms recovered panic values into errors
+	recover func(v interface{}) error
 
 	// INTERNAL
 
@@ -220,6 +229,15 @@ func (b *userSliceLoaderBatch) startTimer(l *UserSliceLoader) {
 }
 
 func (b *userSliceLoaderBatch) end(l *UserSliceLoader) {
+	defer func() {
+		if r := recover(); r != nil {
+			if l.recover != nil {
+				b.error = []error{l.recover(r)}
+			} else {
+				b.error = []error{fmt.Errorf("%v", r)}
+			}
+		}
+	}()
 	b.data, b.error = l.fetch(b.keys)
 	close(b.done)
 }

--- a/example/userloader_gen.go
+++ b/example/userloader_gen.go
@@ -3,6 +3,7 @@
 package example
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -17,6 +18,10 @@ type UserLoaderConfig struct {
 
 	// MaxBatch will limit the maximum number of keys to send in one batch, 0 = not limit
 	MaxBatch int
+
+	// Recover is a function to transform a recovered value into an error.
+	// If a function is not supplied, the value is formatted with fmt.Errorf("%v", v).
+	Recover func(v interface{}) error
 }
 
 // NewUserLoader creates a new UserLoader given a fetch, wait, and maxBatch
@@ -25,6 +30,7 @@ func NewUserLoader(config UserLoaderConfig) *UserLoader {
 		fetch:    config.Fetch,
 		wait:     config.Wait,
 		maxBatch: config.MaxBatch,
+		recover:  config.Recover,
 	}
 }
 
@@ -38,6 +44,9 @@ type UserLoader struct {
 
 	// this will limit the maximum number of keys to send in one batch, 0 = no limit
 	maxBatch int
+
+	// this transforms recovered panic values into errors
+	recover func(v interface{}) error
 
 	// INTERNAL
 
@@ -217,6 +226,15 @@ func (b *userLoaderBatch) startTimer(l *UserLoader) {
 }
 
 func (b *userLoaderBatch) end(l *UserLoader) {
+	defer func() {
+		if r := recover(); r != nil {
+			if l.recover != nil {
+				b.error = []error{l.recover(r)}
+			} else {
+				b.error = []error{fmt.Errorf("%v", r)}
+			}
+		}
+	}()
 	b.data, b.error = l.fetch(b.keys)
 	close(b.done)
 }

--- a/pkg/generator/template.go
+++ b/pkg/generator/template.go
@@ -12,6 +12,7 @@ var tpl = template.Must(template.New("generated").
 package {{.Package}}
 
 import (
+	"fmt"
     "sync"
     "time"
 
@@ -21,7 +22,7 @@ import (
 
 // {{.Name}}Config captures the config to create a new {{.Name}}
 type {{.Name}}Config struct {
-	// Fetch is a method that provides the data for the loader 
+	// Fetch is a method that provides the data for the loader
 	Fetch func(keys []{{.KeyType.String}}) ([]{{.ValType.String}}, []error)
 
 	// Wait is how long wait before sending a batch
@@ -29,6 +30,10 @@ type {{.Name}}Config struct {
 
 	// MaxBatch will limit the maximum number of keys to send in one batch, 0 = not limit
 	MaxBatch int
+
+	// Recover is a function to transform a recovered value into an error.
+	// If a function is not supplied, the value is formatted with fmt.Errorf("%v", v).
+	Recover func(v interface{}) error
 }
 
 // New{{.Name}} creates a new {{.Name}} given a fetch, wait, and maxBatch
@@ -37,10 +42,11 @@ func New{{.Name}}(config {{.Name}}Config) *{{.Name}} {
 		fetch: config.Fetch,
 		wait: config.Wait,
 		maxBatch: config.MaxBatch,
+		recover: config.Recover,
 	}
 }
 
-// {{.Name}} batches and caches requests          
+// {{.Name}} batches and caches requests
 type {{.Name}} struct {
 	// this method provides the data for the loader
 	fetch func(keys []{{.KeyType.String}}) ([]{{.ValType.String}}, []error)
@@ -50,6 +56,9 @@ type {{.Name}} struct {
 
 	// this will limit the maximum number of keys to send in one batch, 0 = no limit
 	maxBatch int
+
+	// this transforms recovered panic values into errors
+	recover func(v interface{}) error
 
 	// INTERNAL
 
@@ -239,6 +248,15 @@ func (b *{{.Name|lcFirst}}Batch) startTimer(l *{{.Name}}) {
 }
 
 func (b *{{.Name|lcFirst}}Batch) end(l *{{.Name}}) {
+	defer func() {
+		if r := recover(); r != nil {
+			if l.recover != nil {
+				b.error = []error{l.recover(r)}
+			} else {
+				b.error = []error{fmt.Errorf("%v", r)}
+			}
+		}
+	}()
 	b.data, b.error = l.fetch(b.keys)
 	close(b.done)
 }


### PR DESCRIPTION
Now a panic inside fetch doesn't take down the whole process.

This also adds a new optional `Recover` field to Config structs to allow control over transforming recovered values into errors. When it's `nil`, `fmt.Errorf("%v", v)` is used.

Fixes #31.