### PR TITLE
Better error message when no package name found

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -100,6 +100,9 @@ func getData(name string, keyType string, valueType string, wd string) (template
 	if genPkg == nil {
 		return templateData{}, fmt.Errorf("unable to find package info for " + wd)
 	}
+	if genPkg.Name == "" {
+		return templateData{}, fmt.Errorf("unable to find package name for " + wd)
+	}
 
 	var err error
 	data.Name = name


### PR DESCRIPTION
Fixes (in a sense) #35

Previously the error message is a bit confusing when no package name found for the working directory (for example, an empty directory).

``` console
$ go run github.com/vektah/dataloaden UserLoader uint64 *example.com/model.User
unable to gofmt:/path/to/example.com/dataloader/userloader_gen.go:6:1: expected 'IDENT', found 'import'
exit status 2
```

This pr makes the message more clear.

``` console
$ go run github.com/vektah/dataloaden UserLoader uint64 *example.com/model.User
unable to find package name for /path/to/example.com/dataloader
exit status 2
```