### PR TITLE
Attempt to fix test flakiness

### DIFF
--- a/example/slice/usersliceloader_test.go
+++ b/example/slice/usersliceloader_test.go
@@ -59,7 +59,7 @@ func TestUserLoader(t *testing.T) {
 
 		t.Run("load many users", func(t *testing.T) {
 			t.Parallel()
-			u, err := dl.LoadAll([]int{2, 10, 20, 4})
+			u, err := dl.LoadAll([]int{2, 30, 20, 4})
 			require.Equal(t, u[0][0].Name, "user 2")
 			require.Error(t, err[1])
 			require.Error(t, err[2])


### PR DESCRIPTION
The tests would sometimes fail when run in parallel. (See #39.)

We'd make the following loads (each line in a subtest):

```
1
10
2 10 20 4
5 50
```

We use batch size 5. The second and third group both load the key 10. We'll always fetch 2 batches and the first has size 5, but the second will have either size 2 or 3 depending on how the tests run. If the second and third group end up in the same batch, we'll get size 2. Otherwise we'll get size 3. However, we assert that the size is always 3.

I solved the problem by changing the 10 in the third group to 30. Now the size of the second batch is always 3.