### PR TITLE
Exclude "sync" and "time" as duplicate imports.

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -113,12 +113,18 @@ func getData(name string, keyType string, valueType string, wd string) (template
 		return templateData{}, fmt.Errorf("key type: %s", err.Error())
 	}
 
-	// if we are inside the same package as the type we don't need an import and can refer directly to the type
-	if genPkg.PkgPath == data.ValType.ImportPath {
+	// If we are inside the same package as the type we don't need
+	// an import and can refer directly to the type.  Also exclude
+	// the "time" package because it is imported by default by the
+	// template.
+	if genPkg.PkgPath == data.ValType.ImportPath ||
+		"time" == data.ValType.ImportPath {
 		data.ValType.ImportName = ""
 		data.ValType.ImportPath = ""
 	}
-	if genPkg.PkgPath == data.KeyType.ImportPath {
+
+	if genPkg.PkgPath == data.KeyType.ImportPath ||
+		"time" == data.KeyType.ImportPath {
 		data.KeyType.ImportName = ""
 		data.KeyType.ImportPath = ""
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -115,16 +115,18 @@ func getData(name string, keyType string, valueType string, wd string) (template
 
 	// If we are inside the same package as the type we don't need
 	// an import and can refer directly to the type.  Also exclude
-	// the "time" package because it is imported by default by the
-	// template.
+	// the "time" and "sync" packages because they are imported by
+	// default by the template.
 	if genPkg.PkgPath == data.ValType.ImportPath ||
-		"time" == data.ValType.ImportPath {
+		"time" == data.ValType.ImportPath ||
+		"sync" == data.ValType.ImportPath {
 		data.ValType.ImportName = ""
 		data.ValType.ImportPath = ""
 	}
 
 	if genPkg.PkgPath == data.KeyType.ImportPath ||
-		"time" == data.KeyType.ImportPath {
+		"time" == data.KeyType.ImportPath ||
+		"sync" == data.KeyType.ImportPath {
 		data.KeyType.ImportName = ""
 		data.KeyType.ImportPath = ""
 	}


### PR DESCRIPTION
Fixes #54 

Basically exclude _sync_ and _time_ packages from being second time imported while generating the *gen.go file. 

Example given: `//go:generate dataloaden fooLoader int *time.Time`