### PR TITLE
Adding the ability to change caching strategy

### DIFF
--- a/example/pkgname/userloader_gen.go
+++ b/example/pkgname/userloader_gen.go
@@ -19,14 +19,62 @@ type UserLoaderConfig struct {
 
 	// MaxBatch will limit the maximum number of keys to send in one batch, 0 = not limit
 	MaxBatch int
+
+	// UserLoaderCache adds ability to change the caching strategy
+	Cache UserLoaderCache
+}
+
+type UserLoaderCache interface {
+	Set(key string, value *example.User)
+	Get(key string) (*example.User, bool)
+	Del(key string)
+}
+
+type UserLoaderDefaultCache struct {
+	cache map[string]*example.User
+}
+
+func NewUserLoaderDefaultCache() *UserLoaderDefaultCache {
+	return &UserLoaderDefaultCache{cache: make(map[string]*example.User)}
+}
+
+func (d *UserLoaderDefaultCache) Set(key string, value *example.User) {
+	d.cache[key] = value
+}
+
+func (d *UserLoaderDefaultCache) Get(key string) (*example.User, bool) {
+	it, ok := d.cache[key]
+	return it, ok
+}
+
+func (d *UserLoaderDefaultCache) Del(key string) {
+	delete(d.cache, key)
+}
+
+type UserLoaderNullCache struct {
+}
+
+func (d *UserLoaderNullCache) Set(key string, value *example.User) {
+}
+
+func (d *UserLoaderNullCache) Get(key string) (*example.User, bool) {
+	return nil, false
+}
+
+func (d *UserLoaderNullCache) Del(key string) {
 }
 
 // NewUserLoader creates a new UserLoader given a fetch, wait, and maxBatch
 func NewUserLoader(config UserLoaderConfig) *UserLoader {
+	cache := config.Cache
+	if cache == nil {
+		cache = NewUserLoaderDefaultCache()
+	}
 	return &UserLoader{
 		fetch:    config.Fetch,
 		wait:     config.Wait,
 		maxBatch: config.MaxBatch,
+		cache:    cache,
 	}
 }
 
@@ -44,7 +92,7 @@ type UserLoader struct {
 	// INTERNAL
 
 	// lazily created cache
-	cache map[string]*example.User
+	cache UserLoaderCache
 
 	// the current batch. keys will continue to be collected until timeout is hit,
 	// then everything will be sent to the fetch method and out to the listeners
@@ -72,7 +120,7 @@ func (l *UserLoader) Load(key string) (*example.User, error) {
 // different data loaders without blocking until the thunk is called.
 func (l *UserLoader) LoadThunk(key string) func() (*example.User, error) {
 	l.mu.Lock()
-	if it, ok := l.cache[key]; ok {
+	if it, ok := l.getCache().Get(key); ok {
 		l.mu.Unlock()
 		return func() (*example.User, error) {
 			return it, nil
@@ -152,7 +200,7 @@ func (l *UserLoader) LoadAllThunk(keys []string) func() ([]*example.User, []erro
 func (l *UserLoader) Prime(key string, value *example.User) bool {
 	l.mu.Lock()
 	var found bool
-	if _, found = l.cache[key]; !found {
+	if _, found = l.getCache().Get(key); !found {
 		// make a copy when writing to the cache, its easy to pass a pointer in from a loop var
 		// and end up with the whole cache pointing to the same value.
 		cpy := *value
@@ -165,15 +213,20 @@ func (l *UserLoader) Prime(key string, value *example.User) bool {
 // Clear the value at key from the cache, if it exists
 func (l *UserLoader) Clear(key string) {
 	l.mu.Lock()
-	delete(l.cache, key)
+	l.getCache().Del(key)
 	l.mu.Unlock()
 }
 
 func (l *UserLoader) unsafeSet(key string, value *example.User) {
+	l.getCache().Set(key, value)
+}
+
+// getCache returns cache object or initializes it
+func (l *UserLoader) getCache() UserLoaderCache {
 	if l.cache == nil {
-		l.cache = map[string]*example.User{}
+		l.cache = NewUserLoaderDefaultCache()
 	}
-	l.cache[key] = value
+	return l.cache
 }
 
 // keyIndex will return the location of the key in the batch, if its not found

--- a/example/slice/usersliceloader_test.go
+++ b/example/slice/usersliceloader_test.go
@@ -203,3 +203,139 @@ func TestUserLoader(t *testing.T) {
 		require.Equal(t, "user 6", users2[0][0].Name)
 	})
 }
+
+func TestUserLoaderWithNullCache(t *testing.T) {
+	var fetches [][]int
+	var mu sync.Mutex
+
+	dl := &UserSliceLoader{
+		wait:     10 * time.Millisecond,
+		maxBatch: 5,
+		fetch: func(keys []int) (users [][]example.User, errors []error) {
+			mu.Lock()
+			fetches = append(fetches, keys)
+			mu.Unlock()
+
+			users = make([][]example.User, len(keys))
+			errors = make([]error, len(keys))
+
+			for i, key := range keys {
+				if key%10 == 0 { // anything ending in zero is bad
+					errors[i] = fmt.Errorf("users not found")
+				} else {
+					users[i] = []example.User{
+						{ID: strconv.Itoa(key), Name: "user " + strconv.Itoa(key)},
+						{ID: strconv.Itoa(key), Name: "user " + strconv.Itoa(key)},
+					}
+				}
+			}
+			return users, errors
+		},
+		cache: &UserSliceLoaderNullCache{},
+	}
+
+	t.Run("fetch concurrent data", func(t *testing.T) {
+		t.Run("load user successfully", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load(1)
+			require.NoError(t, err)
+			require.Equal(t, u[0].ID, "1")
+			require.Equal(t, u[1].ID, "1")
+		})
+
+		t.Run("load failed user", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load(10)
+			require.Error(t, err)
+			require.Nil(t, u)
+		})
+
+		t.Run("load many users", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]int{2, 10, 20, 4})
+			require.Equal(t, u[0][0].Name, "user 2")
+			require.Error(t, err[1])
+			require.Error(t, err[2])
+			require.Equal(t, u[3][0].Name, "user 4")
+		})
+
+		t.Run("load thunk", func(t *testing.T) {
+			t.Parallel()
+			thunk1 := dl.LoadThunk(5)
+			thunk2 := dl.LoadThunk(50)
+
+			u1, err1 := thunk1()
+			require.NoError(t, err1)
+			require.Equal(t, "user 5", u1[0].Name)
+
+			u2, err2 := thunk2()
+			require.Error(t, err2)
+			require.Nil(t, u2)
+		})
+	})
+
+	t.Run("it sent two batches", func(t *testing.T) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, fetches, 2)
+		assert.Len(t, fetches[0], 5)
+		assert.Len(t, fetches[1], 3)
+	})
+
+	t.Run("fetch more", func(t *testing.T) {
+
+		t.Run("previously cached", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load(1)
+			require.NoError(t, err)
+			require.Equal(t, u[0].ID, "1")
+		})
+
+		t.Run("load many users", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]int{2, 4})
+			require.NoError(t, err[0])
+			require.NoError(t, err[1])
+			require.Equal(t, u[0][0].Name, "user 2")
+			require.Equal(t, u[1][0].Name, "user 4")
+		})
+	})
+
+	t.Run("fetch partial", func(t *testing.T) {
+		t.Run("errors not in cache cache value", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load(20)
+			require.Nil(t, u)
+			require.Error(t, err)
+		})
+
+		t.Run("load all", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]int{1, 4, 10, 9, 5})
+			require.Equal(t, u[0][0].ID, "1")
+			require.Equal(t, u[1][0].ID, "4")
+			require.Error(t, err[2])
+			require.Equal(t, u[3][0].ID, "9")
+			require.Equal(t, u[4][0].ID, "5")
+		})
+	})
+
+	t.Run("load all thunk", func(t *testing.T) {
+		thunk1 := dl.LoadAllThunk([]int{5, 6})
+		thunk2 := dl.LoadAllThunk([]int{6, 60})
+
+		users1, err1 := thunk1()
+
+		require.NoError(t, err1[0])
+		require.NoError(t, err1[1])
+		require.Equal(t, "user 5", users1[0][0].Name)
+		require.Equal(t, "user 6", users1[1][0].Name)
+
+		users2, err2 := thunk2()
+
+		require.NoError(t, err2[0])
+		require.Error(t, err2[1])
+		require.Equal(t, "user 6", users2[0][0].Name)
+	})
+}

--- a/example/user_test.go
+++ b/example/user_test.go
@@ -194,3 +194,135 @@ func TestUserLoader(t *testing.T) {
 		require.Equal(t, "user U6", users2[0].Name)
 	})
 }
+
+func TestUserLoaderWithNullCache(t *testing.T) {
+	var fetches [][]string
+	var mu sync.Mutex
+
+	dl := &UserLoader{
+		wait:     10 * time.Millisecond,
+		maxBatch: 5,
+		fetch: func(keys []string) ([]*User, []error) {
+			mu.Lock()
+			fetches = append(fetches, keys)
+			mu.Unlock()
+
+			users := make([]*User, len(keys))
+			errors := make([]error, len(keys))
+
+			for i, key := range keys {
+				if strings.HasPrefix(key, "E") {
+					errors[i] = fmt.Errorf("user not found")
+				} else {
+					users[i] = &User{ID: key, Name: "user " + key}
+				}
+			}
+			return users, errors
+		},
+		cache: &UserLoaderNullCache{},
+	}
+
+	t.Run("fetch concurrent data", func(t *testing.T) {
+		t.Run("load user successfully", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load("U1")
+			require.NoError(t, err)
+			require.Equal(t, u.ID, "U1")
+		})
+
+		t.Run("load failed user", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load("E1")
+			require.Error(t, err)
+			require.Nil(t, u)
+		})
+
+		t.Run("load many users", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]string{"U2", "E2", "E3", "U4"})
+			require.Equal(t, u[0].Name, "user U2")
+			require.Equal(t, u[3].Name, "user U4")
+			require.Error(t, err[1])
+			require.Error(t, err[2])
+		})
+
+		t.Run("load thunk", func(t *testing.T) {
+			t.Parallel()
+			thunk1 := dl.LoadThunk("U5")
+			thunk2 := dl.LoadThunk("E5")
+
+			u1, err1 := thunk1()
+			require.NoError(t, err1)
+			require.Equal(t, "user U5", u1.Name)
+
+			u2, err2 := thunk2()
+			require.Error(t, err2)
+			require.Nil(t, u2)
+		})
+	})
+
+	t.Run("it sent two batches", func(t *testing.T) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, fetches, 2)
+		assert.Len(t, fetches[0], 5)
+		assert.Len(t, fetches[1], 3)
+	})
+
+	t.Run("fetch more", func(t *testing.T) {
+
+		t.Run("previously cached", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load("U1")
+			require.NoError(t, err)
+			require.Equal(t, u.ID, "U1")
+		})
+
+		t.Run("load many users", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]string{"U2", "U4"})
+			require.NoError(t, err[0])
+			require.NoError(t, err[1])
+			require.Equal(t, u[0].Name, "user U2")
+			require.Equal(t, u[1].Name, "user U4")
+		})
+	})
+
+	t.Run("fetch partial", func(t *testing.T) {
+		t.Run("errors not in cache cache value", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.Load("E2")
+			require.Nil(t, u)
+			require.Error(t, err)
+		})
+
+		t.Run("load all", func(t *testing.T) {
+			t.Parallel()
+			u, err := dl.LoadAll([]string{"U1", "U4", "E1", "U9", "U5"})
+			require.Equal(t, u[0].ID, "U1")
+			require.Equal(t, u[1].ID, "U4")
+			require.Error(t, err[2])
+			require.Equal(t, u[3].ID, "U9")
+			require.Equal(t, u[4].ID, "U5")
+		})
+	})
+
+	t.Run("load all thunk", func(t *testing.T) {
+		thunk1 := dl.LoadAllThunk([]string{"U5", "U6"})
+		thunk2 := dl.LoadAllThunk([]string{"U6", "E6"})
+
+		users1, err1 := thunk1()
+
+		require.NoError(t, err1[0])
+		require.NoError(t, err1[1])
+		require.Equal(t, "user U5", users1[0].Name)
+		require.Equal(t, "user U6", users1[1].Name)
+
+		users2, err2 := thunk2()
+
+		require.NoError(t, err2[0])
+		require.Error(t, err2[1])
+		require.Equal(t, "user U6", users2[0].Name)
+	})
+}


### PR DESCRIPTION
It is an attempt to solve the issue https://github.com/vektah/dataloaden/issues/52. 

These changes allow developers to disable caching, if necessary, or change the caching strategy to their own realization.  For example, everybody can change storing data in the map to storing in BigCache, which has an option to set a limit of memory consumption. In our case, it helps us to avoid storing the whole database in memory.

Also, these changes are fully backward compatible.